### PR TITLE
Adding types property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.12",
   "description": "Identifies email addresses or domains names that belong to colleges or universities",
   "main": "index.js",
+  "types": "index.d.ts",
   "homepage": "https://bennymeg.github.io/AcademicEmailVerifier/",
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
This adds the `"types"` property to the package.json. This property informs various providers (such as npmjs.org and skypack) to the existence of typescript definitions for your package.

Example of npm's recognition of typescript definitions from the graphql package:
![image](https://user-images.githubusercontent.com/4484306/116254004-5233a400-a7b4-11eb-9971-1b7f5510426d.png)


See [relevant part of the typescript docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package) for extra info.