### PR TITLE
Add University of Wrocław, Poland

### DIFF
--- a/domains/pl/edu/uwr
+++ b/domains/pl/edu/uwr
@@ -1,0 +1,1 @@
+University of Wrocław


### PR DESCRIPTION
Add University of Wrocław, Poland, with uwr.edu.pl domain. See [here](https://uwr.edu.pl/en/contact-university/). Also see the university's [Wikipedia page](https://en.wikipedia.org/wiki/University_of_Wroc%C5%82aw).